### PR TITLE
Resolvendo o ex. 2 do Cap. 9

### DIFF
--- a/Fad/Chapter9-Ex2.lean
+++ b/Fad/Chapter9-Ex2.lean
@@ -1,0 +1,40 @@
+structure Graph where
+  vertices : List Nat
+  edges : List (Nat × Nat × Nat)
+deriving Repr
+
+structure AdjArray where
+  adjacency : Array (List (Nat × Nat))
+deriving Repr
+
+
+def toAdj (g : Graph) : AdjArray :=
+  let n := g.vertices.length
+  let initArray := Array.mkArray n []
+  let adj := g.edges.foldl
+    (fun acc (u, v, w) =>
+      acc.modify (u - 1) (fun lst => (v, w) :: lst)
+    )
+    initArray
+  { adjacency := adj }
+
+
+def toGraph (adj : AdjArray) : Graph :=
+  let edges := adj.adjacency.toList.enum.foldl
+    (fun acc (u, lst) =>
+      acc ++ lst.map (fun (v, w) => (u + 1, v, w))
+    )
+    []
+  { vertices := List.range adj.adjacency.size |>.map (· + 1), edges := edges }
+
+
+def g : Graph :=
+  { vertices := [1, 2, 3],
+    edges := [(1, 2, 5), (1, 3, 10), (2, 3, 2)] }
+
+#eval toAdj g
+
+
+def adj := toAdj g
+
+#eval toGraph adj


### PR DESCRIPTION
O exercício 9.2 pede a criação de funções para converter entre as representações de um grafo direcionado:

- **toAdj**: Converte um grafo representado por uma lista de vértices e arestas (Graph) em uma matriz de adjacência (AdjArray).

- **toGraph**: Converte uma matriz de adjacência (AdjArray) de volta para a representação de lista de vértices e arestas (Graph).

Os vértices do grafo são numerados consecutivamente a partir de 1, e as arestas possuem pesos associados. 

Resolvi o problema implementando as seguintes funções:

1. **toAdj**:

- Usei _Array.mkArray_ para inicializar a matriz de adjacência como um array de listas vazias.

- Com _foldl_, iterei sobre as arestas do grafo ((u,v,w)) e usei _Array.modify_ para adicionar o par (v,w) à lista correspondente no índice (u−1). Esse ajuste garante que o índice seja compatível com a indexação baseada em 0 do array.

2. **toGraph**:

- Converti o array de adjacências para uma lista com _Array.toList_ e usei _enum_ para obter os índices junto com as listas.

- Com _foldl_, iterei sobre as listas de adjacência e, para cada par (v,w), adicionei uma aresta 
(u+1,v,w), ajustando o índice de volta para o formato. A lista de vértices foi reconstruída diretamente como [1,2,…,n], onde n é o tamanho do array.