### PR TITLE
Finaliza prova do ex 5.7

### DIFF
--- a/Fad/Chapter1-Ex.lean
+++ b/Fad/Chapter1-Ex.lean
@@ -74,15 +74,44 @@ def reverse₀ {α : Type} (a : List α) : List α :=
 def reverse₁ {a : Type} : List a → List a :=
  List.foldl (flip List.cons) []
 
-example {a : Type} (xs : List a) :
-  reverse₁ (reverse₁ (xs)) = xs := by
-    unfold reverse₁
+theorem reverse₁_nil {α : Type} : reverse₁ ([] : List α) = ([] : List α) := rfl
+theorem reverse₁_unique {α : Type} (x : α) : reverse₁ [x] = [x] := rfl
+
+theorem aux_reverse₁_append {α : Type} (as bs: List α) :
+List.foldl (flip List.cons) as bs = (List.foldl (flip List.cons) [] bs) ++ as := by
+  induction bs generalizing as with
+    | nil => rfl
+    | cons c cs ih =>
+      rw [List.foldl, flip]
+      rw [List.foldl, flip]
+      rw [ih, ih [c]]
+      simp
+
+theorem reverse₁_cons : reverse₁ (x::xs) = reverse₁ xs ++ [x] := by
+  rw (occs := .pos [1]) [reverse₁]
+  rw [List.foldl]
+  rw [flip]
+  rw [aux_reverse₁_append]
+  rfl
+
+theorem reverse₁_append {α : Type} (as bs: List α) :
+reverse₁ (as ++ bs) = reverse₁ bs ++ reverse₁ as := by
+  induction as generalizing bs with
+    | nil => simp; rfl
+    | cons c cs ih =>
+      rw [List.cons_append]
+      rw [reverse₁_cons, reverse₁_cons, ← List.append_assoc]
+      rw [ih]
+
+theorem reverse₁_reverse₁_eq_self {α : Type} (xs : List α) : reverse₁ (reverse₁ (xs)) = xs := by
     induction xs with
     | nil => rfl
-    | cons x xs ih =>
-      simp
-      rw [flip]
-      sorry
+    | cons a as ih =>
+      rw [reverse₁_cons]
+      rw [reverse₁_append]
+      rw [reverse₁_unique, ih]
+      rfl
+
 
 theorem foldr_filter_aux :
  ((foldr f e) ∘ (filter p)) ys = foldr f e (filter p ys) := by

--- a/Fad/Chapter5-Ex.lean
+++ b/Fad/Chapter5-Ex.lean
@@ -109,17 +109,26 @@ def T (m n : Nat) : Nat :=
 
 
 example (a b : Nat) : T a b ≤ a + b := by
-  induction a with
+  induction a generalizing b with
   | zero =>
+    rw [T, Nat.zero_add]
+    exact Nat.zero_le b
+  | succ a ha =>
     induction b with
-    | zero => simp [T]
-    | succ b ih => simp [T]
-  | succ a ih₁ =>
-    induction b with
-    | zero => simp [T]
-    | succ b ih₂ =>
-      simp [T]
-      sorry
+    | zero =>
+      rw [T, Nat.add_zero]
+      exact Nat.zero_le (a+1)
+      simp
+    | succ b h2 =>
+      rw [T]
+      have h1 : T a (b + 1) ≤ a + b + 1 := by
+        exact ha (b+1)
+      rw [Nat.succ_add, Nat.succ_add, Nat.zero_add]
+      rw [Nat.succ_le_succ_iff]
+      rw [← Nat.add_assoc]
+      rw [Nat.max_le]
+      rw [Nat.add_assoc, Nat.add_comm 1 b, ← Nat.add_assoc] at h2
+      exact And.intro h1 h2
 
 /- # Exercicio 5.8 : see book -/
 


### PR DESCRIPTION
Acabei de terminar o [Natural Number Game](https://adam.math.hhu.de/#/g/leanprover-community/nng4) e percebi que essa prova era 'parecida' com as coisas de lá, então fui tentar finalizar.

Modificações importantes:
- Alterei a indução no `a` para generalizar o `b`, dessa forma, no passo indutivo a hipótese vale para todo `b` (linha 112).
- 'Instanciei' a hipótese de indução do `a` para um `b` especifico  (linha 124).

O resto foi feito utilizando os lemas padrões dos números naturais.

Obs: No meio do processo descobri que a tática `omega` fechava a prova na linha 126, mas achei meio sem graça e resolvi fazer na mão. A vantagem é que a prova ficou bem mais curta: foi de 271 linhas para 36 linhas.