### PR TITLE
Finalizando prova: qsort0_eq_qsort1

### DIFF
--- a/Fad/Chapter5-Ex.lean
+++ b/Fad/Chapter5-Ex.lean
@@ -12,19 +12,28 @@ namespace Chapter5
 section
 open Quicksort
 
-example (xs : List Nat) : qsort₀ xs = qsort₁ xs := by
-  induction xs with
+theorem qsort₀_eq_qsort₁ [h₁ : LT β] [h₂ : DecidableRel (α := β) (· < ·)]
+(xs : List β) : qsort₀ xs = qsort₁ xs := by
+  cases xs with
   | nil =>
-     unfold qsort₀
-     unfold qsort₁
-     unfold Function.comp
-     unfold mkTree
-     unfold Tree.flatten
-     rfl
-  | cons x xs ih =>
-    simp [qsort₀, Function.comp, mkTree, Tree.flatten] at *
-    unfold qsort₁ at ih
-    sorry
+    rw [qsort₀, Function.comp, mkTree, Tree.flatten]
+    rw [qsort₁]
+  | cons a as =>
+    rw [qsort₀, Function.comp.eq_1 Tree.flatten mkTree]
+    rw [mkTree, Tree.flatten]
+    simp
+    rw [← Function.comp.eq_1 Tree.flatten mkTree, ← qsort₀]
+    rw [← Function.comp.eq_1 Tree.flatten mkTree, ← qsort₀]
+    rw [qsort₁]
+    simp
+    have h₁ := qsort₀_eq_qsort₁ (List.filter (fun x => decide (x < a)) as)
+    have h₂ := qsort₀_eq_qsort₁ (List.filter (not ∘ fun x => decide (x < a)) as)
+    rw [h₁, h₂]
+termination_by xs.length
+  decreasing_by
+    all_goals simp
+    all_goals rw [Nat.lt_add_one_iff]
+    all_goals simp [List.length_filter_le]
 
 end
 


### PR DESCRIPTION
Terminado a prova do issue #64: qsort_0 = qsort_1

Minha primeira abordagem era criar teoremas auxiliares e depois utiliza-los para fechar o teorema principal, na teoria parecia simples, mas ficou muito complicado e não consegui finalizar. 
Em meio as pesquisas encontrei esse [link](https://lean-lang.org/blog/2024-5-17-functional-induction/ ) falando sobre indução funcional que ajudou bastante.

A prova acaba ficando bem direta:
- primeiro para listas vazias o resultado é imediato
- para listas não vazias:
  - abre a definição do qsort_0 e reescreve o mkTree/flatten para ficar como uma recursão qsort_0
  - faz o mesmo pro qsort_1 (como a definição chama recursivamente a própria função, é bem mais direto)
  - cria duas hipóteses chamando recursivamente o próprio teorema que estamos provando e fecha a prova
  - Finalmente, provamos a terminação da recursão do teorema (análogo ao qsort_1)

Achei curioso essa forma de prova porque parece que estamos fazendo uma indução do "final pro começo".